### PR TITLE
Remove hard-coded http: from url

### DIFF
--- a/views/default/framework/fonts/open-sans.php
+++ b/views/default/framework/fonts/open-sans.php
@@ -1,1 +1,1 @@
-<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+<link href='//fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
When using an Elgg site with https Chrome complains when loading http urls
