### PR TITLE
May it fix #80 [WIDGET ENTRIES]? DISCLAIMER: Elgg newbie ;) thanks hypeJunction

### DIFF
--- a/views/default/widgets/wall/content.php
+++ b/views/default/widgets/wall/content.php
@@ -2,6 +2,10 @@
 
 elgg_push_context('wall');
 
+if (!isset($vars['entity']->num_display)) {
+	$vars['entity']->num_display = 4;
+}
+
 $entity = elgg_extract('entity', $vars);
 
 


### PR DESCRIPTION
[Worksforme on Elgg 1.9, never tried in Elgg 2.x]

[commit comment follows]
Setting the default entries limit, avoid and memory leaks
and page loading timeouts when the wall has many entries.

To reproduce the bug: add the Wall widget, do not update its settings,
and create 10 wall posts, you will see 10 posts in the widget.
If you create 100, you will se 100.

To see it is fixed: do the same and when you add the widget if there
are more than 4 posts, you will ever see 4 posts