### PR TITLE
fix(permissions): ElggUser alias included for correct checks

### DIFF
--- a/classes/hypeJunction/Wall/Permissions.php
+++ b/classes/hypeJunction/Wall/Permissions.php
@@ -2,6 +2,8 @@
 
 namespace hypeJunction\Wall;
 
+use ElggUser;
+
 /**
  * @access private
  */


### PR DESCRIPTION
This mistake was producing malfunction when users were trying to write posts on other's walls.